### PR TITLE
Bump requests to fix dependency resolution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ pandas==0.25.3
 # pkg-resources==0.0.0
 python-dateutil==2.8.1
 pytz==2019.3
-requests==2.22.0
+requests==2.31.0
 six==1.13.0
 soupsieve==1.9.5
 urllib3==1.26.5


### PR DESCRIPTION
When setting up the project I ran into:
```
ERROR: Cannot install -r requirements.txt (line 10) and urllib3==1.26.5 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested urllib3==1.26.5
    requests 2.22.0 depends on urllib3!=1.25.0, !=1.25.1, <1.26 and >=1.21.1

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict

ERROR: ResolutionImpossible: for help visit https://pip.pypa.io/en/latest/topics/dependency-resolution/#dealing-with-dependency-conflicts
```